### PR TITLE
WIP see if automatic activation via venv works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,5 +69,10 @@ WORKDIR /home/aiida/code/aiida_core
 RUN $HOME/.venv-py2/bin/pip install --no-cache-dir --no-build-isolation --editable .
 RUN $HOME/.venv-py3/bin/pip install --no-cache-dir --no-build-isolation --editable .
 
+COPY bashrc /home/aiida/.bashrc
+COPY bash_profile /home/aiida/.bash_profile
+
 # Important to end as user root!
 USER root
+RUN chown aiida:aiida /home/aiida/.bashrc
+RUN chown aiida:aiida /home/aiida/.bash_profile

--- a/bash_profile
+++ b/bash_profile
@@ -1,0 +1,5 @@
+# include .bashrc if it exists
+if [ -f ~/.bashrc ]; then
+     . ~/.bashrc
+fi
+ 

--- a/bashrc
+++ b/bashrc
@@ -1,0 +1,63 @@
+# ~/.bashrc: executed by bash(1) for non-login shells.
+# see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
+# for examples
+echo 'in_bashrc'
+case "$AIIDA_DOCKER_VENV" in
+     aiida1.0-py2)
+
+     echo "PY2"
+     source ~/.venv-py2/bin/activate
+     ;;
+     aiida1.0-py3)
+
+     echo "PY3"
+     source ~/.venv-py3/bin/activate
+
+     ;;
+     *)
+     echo default 
+     return;;
+esac
+
+# If not running interactively, don't do anything
+case $- in
+    *i*) ;;
+      *) return;;
+esac
+
+# don't put duplicate lines or lines starting with space in the history.
+# See bash(1) for more options
+HISTCONTROL=ignoreboth
+
+# append to the history file, don't overwrite it
+shopt -s histappend
+
+# for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
+HISTSIZE=1000
+HISTFILESIZE=2000
+
+# check the window size after each command and, if necessary,
+# update the values of LINES and COLUMNS.
+shopt -s checkwinsize
+
+# If set, the pattern "**" used in a pathname expansion context will
+# match all files and zero or more directories and subdirectories.
+#shopt -s globstar
+
+# make less more friendly for non-text input files, see lesspipe(1)
+[ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
+
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+# set a fancy prompt (non-color, unless we know we "want" color)
+case "$TERM" in
+    xterm-color|*-256color) color_prompt=yes;;
+esac
+
+# uncomment for a colored prompt, if the terminal has the capability; turned
+# off by default to not distract the user: the focus in a terminal window
+# should be on the output of commands, not on the prompt
+#force_color_prompt=yes

--- a/test_docker.sh
+++ b/test_docker.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+docker exec -e AIIDA_DOCKER_VENV=aiida1.0-py2 -u aiida testing bash -lc 'verdi --version'
+docker exec -e AIIDA_DOCKER_VENV=aiida1.0-py3 -u aiida testing bash -lc 'verdi --version'
+
+docker exec -e AIIDA_DOCKER_VENV=aiida1.0-py2 -u aiida testing bash -lc 'python --version'
+docker exec -e AIIDA_DOCKER_VENV=aiida1.0-py3 -u aiida testing bash -lc 'python  --version'
+
+# This does not work
+docker exec -e AIIDA_DOCKER_VENV=aiida1.0-py2 -u aiida testing bash -c 'verdi --version'
+docker exec -e AIIDA_DOCKER_VENV=aiida1.0-py3 -u aiida testing bash -c 'verdi --version'
+
+docker exec testing bash -c 'verdi --version'
+docker exec testing bash -c 'python --version'


### PR DESCRIPTION
At the moment it seems bash only source the .bashrc file when launched as a login shell.  
Not sure why, but commands can be executed with `bash -lc'. See the `test_docker.sh` for details.